### PR TITLE
fix package, css and allow for single option selects to still render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# sculptor  [![Build Status](https://travis-ci.org/ordergroove/sculptor.svg)](https://travis-ci.org/ordergroove/sculptor)
+# sculptor
+[![Build Status](https://travis-ci.org/ordergroove/sculptorjs.svg)](https://travis-ci.org/ordergroove/sculptorjs)
+
 Allows you to easily 'sculpt' beautiful, cross-browser HTML dropdowns with standard CSS

--- a/dist/sculptor.css
+++ b/dist/sculptor.css
@@ -1,34 +1,36 @@
 .sculptor-dropdown {
-  border-style: solid;
-  border-width: 1px;
-  cursor: pointer;
-  display: inline-block;
-  padding: 7px 15px 7px 5px;
-  position: relative;
+    border-style: solid;
+    border-width: 1px;
+    cursor: pointer;
+    display: inline-block;
+    margin: 0px;
+    padding: 7px 15px 7px 5px;
+    position: relative;
 }
 .sculptor-dropdown .sculptor-dropdown-options {
-  background: #ffffff;
-  border-style: solid;
-  border-width: 1px;
-  display: none;
-  list-style: none;
-  left: -1px;
-  position: absolute;
-  top: 100%;
-  width: inherit;
-  z-index: 1;
+    background: #ffffff;
+    border-style: solid;
+    border-width: 1px;
+    display: none;
+    list-style: none;
+    left: -1px;
+    padding: 0px;
+    position: absolute;
+    top: 100%;
+    width: inherit;
+    z-index: 1;
 }
 .sculptor-dropdown .sculptor-dropdown-options li {
-  padding: 4px 5px;
+    padding: 4px 5px;
 }
 .sculptor-dropdown:before {
-  content: attr(data-value);
+    content: attr(data-value);
 }
 .sculptor-dropdown:after {
-  content: '\25BC';
-  position: absolute;
-  right: 2px;
+    content: '\25BC';
+    position: absolute;
+    right: 2px;
 }
 .sculptor-dropdown.sculptor-dropdown-opened .sculptor-dropdown-options {
-  display: block;
+    display: block;
 }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "private": false,
   "copyright": "2015",
   "license": "MIT",
-  "main": ".dist/sculptor.js",
+  "main": "./src/sculptor.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ordergroove/sculptor"
+    "url": "https://github.com/ordergroove/sculptorjs"
   },
   "dependencies": {
     "pocket-dom": "^1.0.2"

--- a/src/sculptor.js
+++ b/src/sculptor.js
@@ -18,7 +18,7 @@
             len = select.length;
 
         // starts only if select has options
-        if (len > 1) {
+        if (len > 0) {
             // generate element
             customElement = doc.createElement('div');
             dom.addClass(customElement, 'sculptor-dropdown');

--- a/src/sculptor.less
+++ b/src/sculptor.less
@@ -3,6 +3,7 @@
     border-width: 1px;
     cursor: pointer;
     display: inline-block;
+    margin: 0px;
     padding: 7px 15px 7px 5px;
     position: relative;
 
@@ -13,6 +14,7 @@
         display: none;
         list-style: none;
         left: -1px;
+        padding: 0px;
         position: absolute;
         top: 100%;
         width: inherit;


### PR DESCRIPTION
@jeremenichelli this will resolve some aforementioned issues around:
- pointing to browserified version of sculptor.js file in package.json
- overriding default css behavior or ul
- allow styling of dropdowns with a single option
